### PR TITLE
Ditaa ascii art conversion

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -38,7 +38,9 @@ needs_sphinx = '1.3'
 # ones.
 extensions = ['kerneldoc', 'rstFlatTable', 'kernel_include', 'cdomain',
               'kfigure', 'sphinx.ext.ifconfig', 'automarkup',
-              'maintainers_include', 'sphinx.ext.autosectionlabel' ]
+              'maintainers_include', 'sphinx.ext.autosectionlabel',
+            #   'sphinxcontrib.aafig']
+              'sphinxcontrib.ditaa']
 
 # Ensure that autosectionlabel will produce unique names
 autosectionlabel_prefix_document = True
@@ -569,6 +571,36 @@ epub_exclude_files = ['search.html']
 
 # If false, no index is generated.
 #epub_use_index = True
+
+
+# -- Options for Ditaa output ----------------------------------------------
+
+# Please see the Sphinx Ditaa extension descriptin here:
+# https://pypi.org/project/sphinxcontrib-ditaa/
+# "Ditaa is a java implementation and maybe is not callable directly, please
+# input the ditaa executale name if you didn’t convert it to a normal command.
+# Default is “ditaa”. See examples below."
+# "One possilbe convertation might be like this:
+# | $ cat /usr/local/bin/ditaa
+# | #!/bin/bash
+# | exec java  -jar /usr/local/Cellar/ditaa/0.10/libexec/ditaa0_10.jar "$@" "
+# Other way to put the path to the java exec here:
+ditaa = "java"
+# Note: The origin of the path mentioned at sphinxcontrib-ditaa page is
+# unclear. At the time of writing, the ditaa.sourceforge.net keeps link to
+# ver.9 of this java file that can be placed anywere, e.g.:
+ditaa_args = ["-jar", "/home/some-user/Downloads/Ditaa/ditaa0_9.jar"]
+
+# This is for generating svg output.
+#ditaa_args = ['--svg']
+#ditaa_output_suffix = 'svg'
+# The default values is for png: ditaa_output_suffix = 'png'
+ditaa_output_suffix = 'png'
+
+# "Since ditaa is slow, will give out a log to note progress if it’s
+# configured. Default is True."
+ditaa_log_enable = True
+
 
 #=======
 # rst2pdf

--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -38,9 +38,7 @@ needs_sphinx = '1.3'
 # ones.
 extensions = ['kerneldoc', 'rstFlatTable', 'kernel_include', 'cdomain',
               'kfigure', 'sphinx.ext.ifconfig', 'automarkup',
-              'maintainers_include', 'sphinx.ext.autosectionlabel',
-            #   'sphinxcontrib.aafig']
-              'sphinxcontrib.ditaa']
+              'maintainers_include', 'sphinx.ext.autosectionlabel' ]
 
 # Ensure that autosectionlabel will produce unique names
 autosectionlabel_prefix_document = True
@@ -571,36 +569,6 @@ epub_exclude_files = ['search.html']
 
 # If false, no index is generated.
 #epub_use_index = True
-
-
-# -- Options for Ditaa output ----------------------------------------------
-
-# Please see the Sphinx Ditaa extension descriptin here:
-# https://pypi.org/project/sphinxcontrib-ditaa/
-# "Ditaa is a java implementation and maybe is not callable directly, please
-# input the ditaa executale name if you didn’t convert it to a normal command.
-# Default is “ditaa”. See examples below."
-# "One possilbe convertation might be like this:
-# | $ cat /usr/local/bin/ditaa
-# | #!/bin/bash
-# | exec java  -jar /usr/local/Cellar/ditaa/0.10/libexec/ditaa0_10.jar "$@" "
-# Other way to put the path to the java exec here:
-ditaa = "java"
-# Note: The origin of the path mentioned at sphinxcontrib-ditaa page is
-# unclear. At the time of writing, the ditaa.sourceforge.net keeps link to
-# ver.9 of this java file that can be placed anywere, e.g.:
-ditaa_args = ["-jar", "/home/some-user/Downloads/Ditaa/ditaa0_9.jar"]
-
-# This is for generating svg output.
-#ditaa_args = ['--svg']
-#ditaa_output_suffix = 'svg'
-# The default values is for png: ditaa_output_suffix = 'png'
-ditaa_output_suffix = 'png'
-
-# "Since ditaa is slow, will give out a log to note progress if it’s
-# configured. Default is True."
-ditaa_log_enable = True
-
 
 #=======
 # rst2pdf

--- a/Documentation/scheduler/overview.rst
+++ b/Documentation/scheduler/overview.rst
@@ -233,48 +233,27 @@ Scheduler State Transition
 A very high level scheduler state transition flow with a few states can
 be depicted as follows.
 
-.. ditaa::
-   :alt: digraph of Scheduler state transition.
+.. kernel-render:: DOT
+   :alt: DOT digraph of Scheduler state transition
+   :caption: Scheduler state transition
 
-                                       *
-                                       |
-                                       | task
-                                       | forks
-                                       v
-                        +------------------------------+
-                        |           TASK_NEW           |
-                        |        (Ready to run)        |
-                        +------------------------------+
-                                       |
-                                       |
-   int                                 v
-                     +------------------------------------+
-                     |            TASK_RUNNING            |
-   +---------------> |           (Ready to run)           | <--+
-   |                 +------------------------------------+    |
-   |                   |                                       |
-   |                   | schedule() calls context_switch()     | task is pre-empted
-   |                   v                                       |
-   |                 +------------------------------------+    |
-   |                 |            TASK_RUNNING            |    |
-   |                 |             (Running)              | ---+
-   | event occurred  +------------------------------------+
-   |                   |
-   |                   | task needs to wait for event
-   |                   v
-   |                 +------------------------------------+
-   |                 |         TASK_INTERRUPTIBLE         |
-   |                 |        TASK_UNINTERRUPTIBLE        |
-   +-----------------|           TASK_WAKEKILL            |
-                     +------------------------------------+
-                                       |
-                                       | task exits via do_exit()
-                                       v
-                        +------------------------------+
-                        |          TASK_DEAD           |
-                        |         EXIT_ZOMBIE          |
-                        +------------------------------+
-
+   digraph sched_transition {
+      node [shape = point,  label="exisiting task\n calls fork()"]; fork
+      node [shape = box, label="TASK_NEW\n(Ready to run)"] tsk_new;
+      node [shape = box, label="TASK_RUNNING\n(Ready to run)"] tsk_ready_run;
+      node [shape = box, label="TASK_RUNNING\n(Running)"] tsk_running;
+      node [shape = box, label="TASK_DEAD\nEXIT_ZOMBIE"] exit_zombie;
+      node [shape = box, label="TASK_INTERRUPTIBLE\nTASK_UNINTERRUPTIBLE\nTASK_WAKEKILL"] tsk_int;
+      fork -> tsk_new [ label = "task\nforks" ];
+      tsk_new -> tsk_ready_run;
+      tsk_ready_run -> tsk_running [ label = "schedule() calls context_switch()" ];
+      tsk_running -> tsk_ready_run [ label = "task is pre-empted" ];
+      subgraph int {
+         tsk_running -> tsk_int [ label = "task needs to wait for event" ];
+         tsk_int ->  tsk_ready_run [ label = "event occurred" ];
+      }
+      tsk_int ->  exit_zombie [ label = "task exits via do_exit()" ];
+   }
 
 Scheduler provides trace points tracing all major events of the scheduler.
 The tracepoints are defined in ::

--- a/Documentation/scheduler/overview.rst
+++ b/Documentation/scheduler/overview.rst
@@ -233,27 +233,48 @@ Scheduler State Transition
 A very high level scheduler state transition flow with a few states can
 be depicted as follows.
 
-.. kernel-render:: DOT
-   :alt: DOT digraph of Scheduler state transition
-   :caption: Scheduler state transition
+.. ditaa::
+   :alt: digraph of Scheduler state transition.
 
-   digraph sched_transition {
-      node [shape = point,  label="exisiting task\n calls fork()"]; fork
-      node [shape = box, label="TASK_NEW\n(Ready to run)"] tsk_new;
-      node [shape = box, label="TASK_RUNNING\n(Ready to run)"] tsk_ready_run;
-      node [shape = box, label="TASK_RUNNING\n(Running)"] tsk_running;
-      node [shape = box, label="TASK_DEAD\nEXIT_ZOMBIE"] exit_zombie;
-      node [shape = box, label="TASK_INTERRUPTIBLE\nTASK_UNINTERRUPTIBLE\nTASK_WAKEKILL"] tsk_int;
-      fork -> tsk_new [ label = "task\nforks" ];
-      tsk_new -> tsk_ready_run;
-      tsk_ready_run -> tsk_running [ label = "schedule() calls context_switch()" ];
-      tsk_running -> tsk_ready_run [ label = "task is pre-empted" ];
-      subgraph int {
-         tsk_running -> tsk_int [ label = "task needs to wait for event" ];
-         tsk_int ->  tsk_ready_run [ label = "event occurred" ];
-      }
-      tsk_int ->  exit_zombie [ label = "task exits via do_exit()" ];
-   }
+                                       *
+                                       |
+                                       | task
+                                       | forks
+                                       v
+                        +------------------------------+
+                        |           TASK_NEW           |
+                        |        (Ready to run)        |
+                        +------------------------------+
+                                       |
+                                       |
+   int                                 v
+                     +------------------------------------+
+                     |            TASK_RUNNING            |
+   +---------------> |           (Ready to run)           | <--+
+   |                 +------------------------------------+    |
+   |                   |                                       |
+   |                   | schedule() calls context_switch()     | task is pre-empted
+   |                   v                                       |
+   |                 +------------------------------------+    |
+   |                 |            TASK_RUNNING            |    |
+   |                 |             (Running)              | ---+
+   | event occurred  +------------------------------------+
+   |                   |
+   |                   | task needs to wait for event
+   |                   v
+   |                 +------------------------------------+
+   |                 |         TASK_INTERRUPTIBLE         |
+   |                 |        TASK_UNINTERRUPTIBLE        |
+   +-----------------|           TASK_WAKEKILL            |
+                     +------------------------------------+
+                                       |
+                                       | task exits via do_exit()
+                                       v
+                        +------------------------------+
+                        |          TASK_DEAD           |
+                        |         EXIT_ZOMBIE          |
+                        +------------------------------+
+
 
 Scheduler provides trace points tracing all major events of the scheduler.
 The tracepoints are defined in ::


### PR DESCRIPTION
The Ditaa way is reverted (but kept in the commit history to get back to it after syncing with 'sphinxcontrib-ditaa' Sphinx extension maintainers) as risky and only 'ASCII Art' diagram is kept. 